### PR TITLE
Sweep requires size invariant

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -27,7 +27,7 @@ extern GarbageCollector gc;  // Global garbage collector for all
 void gc_start(GarbageCollector* gc, void* bos);
 void gc_start_ext(GarbageCollector* gc, void* bos, size_t initial_size, size_t min_size,
                   double downsize_load_factor, double upsize_load_factor, double sweep_factor);
-void gc_stop(GarbageCollector* gc);
+size_t gc_stop(GarbageCollector* gc);
 void gc_pause(GarbageCollector* gc);
 void gc_resume(GarbageCollector* gc);
 size_t gc_run(GarbageCollector* gc);


### PR DESCRIPTION
Fixes an issue where `gc_sweep()` will trigger a premature `gc_allocation_map_resize()` and cause a memory leak.