### PR TITLE
Fixed gcc bugs | Issue: #17

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -3,11 +3,15 @@ name: C/C++ CI
 on: [push]
 
 jobs:
-  build:
-
+  build_clang:
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@v1
-    - name: make test
-      run: make test
+    - name: make test (clang)
+      run: make test CC=clang
+  build_gcc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1      
+    - name: make test (gcc)
+      run: make test CC=gcc

--- a/src/gc.c
+++ b/src/gc.c
@@ -237,7 +237,9 @@ static Allocation* gc_allocation_map_get(AllocationMap* am, void* ptr)
     // LOG_DEBUG("GET request for allocation ix=%ld (ptr=%p)", index, ptr);
     Allocation* cur = am->allocs[index];
     while(cur) {
-        if (cur->ptr == ptr) return cur;
+        if (cur->ptr == ptr) {
+            return cur;
+        }
         cur = cur->next;
     }
     return NULL;
@@ -543,12 +545,8 @@ void gc_mark(GarbageCollector* gc)
     LOG_DEBUG("Initiating GC mark (gc@%p)", (void*) gc);
     /* Scan the heap for roots */
     gc_mark_roots(gc);
-    /* Dump registers onto stack and scan the stack */
-    void (*volatile _mark_stack)(GarbageCollector*) = gc_mark_stack;
-    jmp_buf ctx;
-    memset(&ctx, 0, sizeof(jmp_buf));
-    setjmp(ctx);
-    _mark_stack(gc);
+
+    gc_mark_stack(gc);
 }
 
 size_t gc_sweep(GarbageCollector* gc)

--- a/src/gc.c
+++ b/src/gc.c
@@ -509,8 +509,7 @@ void gc_mark_alloc(GarbageCollector* gc, void* ptr)
 void gc_mark_stack(GarbageCollector* gc)
 {
     LOG_DEBUG("Marking the stack (gc@%p) in increments of %ld", (void*) gc, sizeof(char));
-    char dummy;
-    void *tos = (void*) &dummy;
+    void *tos = __builtin_frame_address(0);
     void *bos = gc->bos;
     if (tos > bos) {
         void* tmp = tos;

--- a/src/gc.c
+++ b/src/gc.c
@@ -545,8 +545,12 @@ void gc_mark(GarbageCollector* gc)
     LOG_DEBUG("Initiating GC mark (gc@%p)", (void*) gc);
     /* Scan the heap for roots */
     gc_mark_roots(gc);
-
-    gc_mark_stack(gc);
+    /* Dump registers onto stack and scan the stack */
+    void (*volatile _mark_stack)(GarbageCollector*) = gc_mark_stack;
+    jmp_buf ctx;
+    memset(&ctx, 0, sizeof(jmp_buf));
+    setjmp(ctx);
+    _mark_stack(gc);
 }
 
 size_t gc_sweep(GarbageCollector* gc)

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -356,7 +356,7 @@ static char* test_gc_pause_resume()
 {
     GarbageCollector gc_;
     void *bos = __builtin_frame_address(0);
-    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
+    gc_start(&gc_, &bos);
     /* allocate a bunch of vars in a deeper stack frame */
     size_t N = 32;
     _create_allocs(&gc_, N, 8);
@@ -379,7 +379,7 @@ char* test_gc_strdup()
 {
     GarbageCollector gc_;
     void *bos = __builtin_frame_address(0);
-    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
+    gc_start(&gc_, bos);
     char* str = "This is a string";
     duplicate_string(&gc_, str);
     size_t collected = gc_run(&gc_);

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -369,15 +369,19 @@ static char* test_gc_pause_resume()
     return NULL;
 }
 
+static void* duplicate_string(GarbageCollector* gc, char* str)
+{
+    char* copy = (char*) gc_strdup(gc, str);
+    mu_assert(strncmp(str, copy, 16) == 0, "Strings should be equal");
+}
+
 char* test_gc_strdup()
 {
     GarbageCollector gc_;
     void *bos = __builtin_frame_address(0);
     gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
     char* str = "This is a string";
-    char* copy = (char*) gc_strdup(&gc_, str);
-    mu_assert(strncmp(str, copy, 16) == 0, "Strings should be equal");
-    copy = NULL;
+    duplicate_string(&gc_, str);
     size_t collected = gc_run(&gc_);
     mu_assert(collected == 17, "Unexpected number of collected bytes");
     return NULL;

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -309,7 +309,7 @@ static char* test_gc_static_allocation()
     DTOR_COUNT = 0;
     GarbageCollector gc_;
     void *bos = __builtin_frame_address(0);
-    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
+    gc_start(&gc_, &bos);
     /* allocate a bunch of static vars in a deeper stack frame */
     size_t N = 256;
     _create_static_allocs(&gc_, N, 512);
@@ -372,8 +372,8 @@ static char* test_gc_pause_resume()
 char* test_gc_strdup()
 {
     GarbageCollector gc_;
-    int bos;
-    gc_start(&gc_, &bos);
+    void *bos = __builtin_frame_address(0);
+    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
     char* str = "This is a string";
     char* copy = (char*) gc_strdup(&gc_, str);
     mu_assert(strncmp(str, copy, 16) == 0, "Strings should be equal");

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -246,8 +246,8 @@ static char* test_gc_basic_alloc_free()
      */
     DTOR_COUNT = 0;
     GarbageCollector gc_;
-    int bos;
-    gc_start_ext(&gc_, &bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
+    void *bos = __builtin_frame_address(0);
+    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
 
     int** ints = gc_calloc(&gc_, 16, sizeof(int*));
     Allocation* a = gc_allocation_map_get(gc_.allocs, ints);

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -159,8 +159,8 @@ static char* test_gc_allocation_map_cleanup()
      */
     DTOR_COUNT = 0;
     GarbageCollector gc_;
-    int bos;
-    gc_start_ext(&gc_, &bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
+    void *bos = __builtin_frame_address(0);
+    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
 
     /* run a few alloc/free cycles */
     int** ptrs = gc_malloc_ext(&gc_, 64*sizeof(int*), dtor);

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -187,8 +187,7 @@ static char* test_gc_allocation_map_cleanup()
 static char* test_gc_mark_stack()
 {
     GarbageCollector gc_;
-    int bos;
-    gc_start_ext(&gc_, &bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
+    gc_start_ext(&gc_, __builtin_frame_address(0), 32, 32, 0.0, DBL_MAX, DBL_MAX);
     gc_pause(&gc_);
 
     /* Part 1: Create an object on the heap, reference from the stack,

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -355,8 +355,8 @@ static void _create_allocs(GarbageCollector* gc,
 static char* test_gc_pause_resume()
 {
     GarbageCollector gc_;
-    int bos;
-    gc_start(&gc_, &bos);
+    void *bos = __builtin_frame_address(0);
+    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
     /* allocate a bunch of vars in a deeper stack frame */
     size_t N = 32;
     _create_allocs(&gc_, N, 8);

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -308,8 +308,8 @@ static char* test_gc_static_allocation()
 {
     DTOR_COUNT = 0;
     GarbageCollector gc_;
-    int bos;
-    gc_start_ext(&gc_, &bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
+    void *bos = __builtin_frame_address(0);
+    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
     /* allocate a bunch of static vars in a deeper stack frame */
     size_t N = 256;
     _create_static_allocs(&gc_, N, 512);

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -187,7 +187,8 @@ static char* test_gc_allocation_map_cleanup()
 static char* test_gc_mark_stack()
 {
     GarbageCollector gc_;
-    gc_start_ext(&gc_, __builtin_frame_address(0), 32, 32, 0.0, DBL_MAX, DBL_MAX);
+    void *bos = __builtin_frame_address(0);
+    gc_start_ext(&gc_, bos, 32, 32, 0.0, DBL_MAX, DBL_MAX);
     gc_pause(&gc_);
 
     /* Part 1: Create an object on the heap, reference from the stack,


### PR DESCRIPTION
This solves stack marking problem in GCC while maintaining compatibility with clang. But still TC 6 is failing: `Referenced allocs should be marked`, which I'll raise an issue and PR for 