### PR TITLE
Refine gc_sweep() function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ size_t gc_sweep(GarbageCollector* gc, bool clearAll)
         Allocation* chunk = gc->allocs->allocs[i];
         Allocation* next = NULL;
         while (chunk) {
-            if ((clearAll==false) && (chunk->tag & GC_TAG_MARK)) {
+            if ((clearAll == false) && (chunk->tag & GC_TAG_MARK)) {
                 /* unmark */
                 chunk->tag &= ~GC_TAG_MARK;
                 chunk = chunk->next;

--- a/README.md
+++ b/README.md
@@ -388,14 +388,14 @@ use, collecting the unreachable allocations is trivial. Here is the
 implementation from `gc_sweep()`:
 
 ```c
-size_t gc_sweep(GarbageCollector* gc)
+size_t gc_sweep(GarbageCollector* gc, bool clearAll)
 {
     size_t total = 0;
     for (size_t i = 0; i < gc->allocs->capacity; ++i) {
         Allocation* chunk = gc->allocs->allocs[i];
         Allocation* next = NULL;
         while (chunk) {
-            if (chunk->tag & GC_TAG_MARK) {
+            if ((clearAll==false) && (chunk->tag & GC_TAG_MARK)) {
                 /* unmark */
                 chunk->tag &= ~GC_TAG_MARK;
                 chunk = chunk->next;

--- a/src/gc.c
+++ b/src/gc.c
@@ -554,7 +554,7 @@ size_t gc_sweep(GarbageCollector* gc, bool clearAll)
         Allocation* next = NULL;
         /* Iterate over separate chaining */
         while (chunk) {
-            if ((clearAll==false) && (chunk->tag & GC_TAG_MARK)) {
+            if ((clearAll == false) && (chunk->tag & GC_TAG_MARK)) {
                 LOG_DEBUG("Found used allocation %p (ptr=%p)", (void*) chunk, (void*) chunk->ptr);
                 /* unmark */
                 chunk->tag &= ~GC_TAG_MARK;

--- a/src/gc.c
+++ b/src/gc.c
@@ -545,7 +545,7 @@ void gc_mark(GarbageCollector* gc)
     _mark_stack(gc);
 }
 
-size_t gc_sweep(GarbageCollector* gc)
+size_t gc_sweep(GarbageCollector* gc, bool clearAll)
 {
     LOG_DEBUG("Initiating GC sweep (gc@%p)", (void*) gc);
     size_t total = 0;
@@ -554,7 +554,7 @@ size_t gc_sweep(GarbageCollector* gc)
         Allocation* next = NULL;
         /* Iterate over separate chaining */
         while (chunk) {
-            if (chunk->tag & GC_TAG_MARK) {
+            if ((clearAll==false) && (chunk->tag & GC_TAG_MARK)) {
                 LOG_DEBUG("Found used allocation %p (ptr=%p)", (void*) chunk, (void*) chunk->ptr);
                 /* unmark */
                 chunk->tag &= ~GC_TAG_MARK;
@@ -600,7 +600,7 @@ void gc_unroot_roots(GarbageCollector* gc)
 size_t gc_stop(GarbageCollector* gc)
 {
     gc_unroot_roots(gc);
-    size_t collected = gc_sweep(gc);
+    size_t collected = gc_sweep(gc, true);
     gc_allocation_map_delete(gc->allocs);
     return collected;
 }
@@ -609,7 +609,7 @@ size_t gc_run(GarbageCollector* gc)
 {
     LOG_DEBUG("Initiating GC run (gc@%p)", (void*) gc);
     gc_mark(gc);
-    return gc_sweep(gc);
+    return gc_sweep(gc, false);
 }
 
 char* gc_strdup (GarbageCollector* gc, const char* s)

--- a/test/test_gc.c
+++ b/test/test_gc.c
@@ -237,9 +237,6 @@ static char* test_gc_mark_stack()
     mu_assert(a->tag & GC_TAG_MARK, "Referenced alloc should be tagged");
     mu_assert(unmarked_alloc->tag == GC_TAG_NONE, "Unreferenced alloc should not be tagged");
 
-    gc_free(&gc_, unmarked_alloc->ptr);
-    gc_free(&gc_, five_ptr[0]);
-    gc_free(&gc_, five_ptr);
     gc_stop(&gc_);
     return NULL;
 }
@@ -295,7 +292,7 @@ static char* test_gc_basic_alloc_free()
     mu_assert(total == 16 * sizeof(int) + 16 * sizeof(int*),
               "Expected number of managed bytes is off");
 
-    size_t n = gc_sweep(&gc_);
+    size_t n = gc_sweep(&gc_, false);
     mu_assert(n == total, "Wrong number of collected bytes");
     mu_assert(DTOR_COUNT == 16, "Failed to call destructor");
     DTOR_COUNT = 0;
@@ -345,7 +342,7 @@ static char* test_gc_static_allocation()
     mu_assert(n == N, "Expected number of allocations is off");
     mu_assert(total == N*512, "Expected number of managed bytes is off");
     /* make sure we collect everything */
-    collected = gc_sweep(&gc_);
+    collected = gc_sweep(&gc_, false);
     mu_assert(collected == N*512, "Unexpected number of bytes");
     mu_assert(DTOR_COUNT == N, "Failed to call destructor");
     DTOR_COUNT = 0;


### PR DESCRIPTION
This patch will make gc_stop() will always work correct, and prevent memory leak.
