### PR TITLE
Remove valgrind `InvalidRead` warnings.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -504,7 +504,7 @@ void gc_mark_alloc(GarbageCollector* gc, void* ptr)
         /* Iterate over allocation contents and mark them as well */
         LOG_DEBUG("Checking allocation (ptr=%p, size=%lu) contents", ptr, alloc->size);
         for (char* p = (char*) alloc->ptr;
-                p < (char*) alloc->ptr + alloc->size;
+                p <= (char*) alloc->ptr + alloc->size - sizeof(char*);
                 ++p) {
             LOG_DEBUG("Checking allocation (ptr=%p) @%lu with value %p",
                       ptr, p-((char*) alloc->ptr), *(void**)p);
@@ -517,9 +517,9 @@ void gc_mark_stack(GarbageCollector* gc)
 {
     LOG_DEBUG("Marking the stack (gc@%p) in increments of %ld", (void*) gc, sizeof(char));
     void *tos = __builtin_frame_address(0);
-    void *bos = gc->bos;
+    void *bos = (char*)gc->bos - sizeof(char*);
     /* The stack grows towards smaller memory addresses, hence we scan tos->bos */
-    for (char* p = (char*) tos; p < (char*) bos; ++p) {
+    for (char* p = (char*) tos; p <= (char*) bos; ++p) {
         gc_mark_alloc(gc, *(void**)p);
     }
 }


### PR DESCRIPTION
prevent pointer size less than sizeof(char*).

![image](https://user-images.githubusercontent.com/30760636/71925238-91a73d00-31cb-11ea-81c6-597554190821.png)
