### PR TITLE
Fix memory violation

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -29,7 +29,7 @@
 #define GC_TAG_ROOT 0x1
 #define GC_TAG_MARK 0x2
 
-/* 
+/*
  * Support for windows c compiler is added by adding this macro.
  * Tested on: Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28314 for x86
  */
@@ -446,8 +446,9 @@ void* gc_realloc(GarbageCollector* gc, void* p, size_t size)
         alloc->size = size;
     } else {
         // successful reallocation w/ copy
+        void (*dtor)(void*) = alloc->dtor;
         gc_allocation_map_remove(gc->allocs, p, true);
-        gc_allocation_map_put(gc->allocs, q, size, alloc->dtor);
+        gc_allocation_map_put(gc->allocs, q, size, dtor);
     }
     return q;
 }


### PR DESCRIPTION
The code was accessing data from a memory region previously released. The following memory violation was caught by Valgrind:

```
Invalid read of size 8
   at 0x10BC4D: gc_realloc (gc.c:451)
   by 0x10E7E3: test_gc_realloc (test_gc.c:393)
   by 0x10EFA7: test_suite (test_gc.c:473)
   by 0x10F0B5: main (test_gc.c:481)
```