### PR TITLE
Add CMake and Visual Studio support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Visual Studio garbage
+out/
+.vs/
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.0)
+project(gc C)
+include_directories(src test)
+add_library(gc src/gc.c src/log.c)
+add_executable(test_gc test/test_gc.c)
+target_link_libraries(test_gc gc)
+enable_testing()
+add_test(NAME test_gc COMMAND test_gc)

--- a/src/gc.c
+++ b/src/gc.c
@@ -34,6 +34,7 @@
  * Tested on: Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28314 for x86
  */
 #if defined(_MSC_VER)
+#include <intrin.h>
 #define __builtin_frame_address(x)  ((void)(x), _AddressOfReturnAddress())
 #endif
 


### PR DESCRIPTION
Related to #41 but properly implements CMake build system.
Testing capabilities are preserved via `CTest`.
An include is added because otherwise building with `clang-cl` fails (required function is defined in `intrin.h`).
Unfortunately, the actual test fails -- for now -- but at least it compiles and works well with Visual Studio :)