### PR TITLE
Fix compilation on Windows when using standalone clang

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -33,7 +33,7 @@
  * Support for windows c compiler is added by adding this macro.
  * Tested on: Microsoft (R) C/C++ Optimizing Compiler Version 19.24.28314 for x86
  */
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 #define __builtin_frame_address(x)  ((void)(x), _AddressOfReturnAddress())
 #endif
 


### PR DESCRIPTION
Trying to compile `gc.c` using Clang 18.1.8 on Windows (the standalone version from the installer found in [LLVM's releases page](https://github.com/llvm/llvm-project/releases/), not the MSYS2 version; that works fine) generates an "undeclared library function _AddressOfReturnAddress" error when expanding the `__builtin_frame_address` macro.

Clang supports the `__builtin_frame_address` built-in on Windows even in the MSVC environment, so the macro doesn't even need to exist when compiling with it.

This PR fixes the issue with a little check to omit the macro when `__clang__` is defined.